### PR TITLE
Set the current working directory of the process

### DIFF
--- a/ruby_markers.py
+++ b/ruby_markers.py
@@ -28,7 +28,12 @@ class RubyMarkersCommand(sublime_plugin.TextCommand):
             cmd.append(self.settings.get("xmpfilter_bin_posix", "xmpfilter"))
 
         try:
-            currentdir = os.path.dirname(self.view.file_name())
+            currentfile = self.view.file_name()
+            if currentfile == None:
+                currentdir = os.path.expanduser('~')
+            else:
+                currentdir = os.path.dirname(currentfile)
+
             s = subprocess.Popen(
                 cmd,
                 stdin=subprocess.PIPE,


### PR DESCRIPTION
rbenv uses the current working directory to set the ruby version (https://github.com/sstephenson/rbenv#choosing-the-ruby-version). Ruby Markers should set the current directory of the subprocess to that of the current view (prevents many many headaches!) or default to the user's home

Note: I'm not typically a Python coder or Sublime plugin author but the code works reliably for me (ST2, OS X). Not sure how to make this work correctly on Windows
